### PR TITLE
Update python-telegram-bot dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-telegram-bot==20.7
+python-telegram-bot>=21


### PR DESCRIPTION
## Summary
- update the python-telegram-bot dependency requirement to allow version 21 and later

## Testing
- pip install -r requirements.txt *(fails: network proxy blocks access to PyPI)*

------
https://chatgpt.com/codex/tasks/task_e_68d13e9afac08323bae0500c31dd41d8